### PR TITLE
Fix Releases Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
       API Docs
     </a>
     <span> | </span>
-    <a href="https://github.com/async-rs/async-std/releases">
+    <a href="https://github.com/yoshuawuyts/chic/releases">
       Releases
     </a>
     <span> | </span>


### PR DESCRIPTION
The releases link previously pointed to the async-std releases page.