### PR TITLE
Upgrade `annotate-snippets` to `0.9.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-annotate-snippets = "0.6.1"
+annotate-snippets = "0.9.1"
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,24 +1,27 @@
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
+use annotate_snippets::display_list::{DisplayList, FormatOptions};
 use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 
 /// An error formatter.
-pub struct Error {
-    snippet: Snippet,
+pub struct Error<'a> {
+    snippet: Snippet<'a>,
 }
 
-impl Error {
+impl<'a> Error<'a> {
     /// Create a new `Error` formatter.
-    pub fn new(label: impl ToString) -> Self {
+    pub fn new(label: &'a str) -> Self {
         Self {
             snippet: Snippet {
                 title: Some(Annotation {
-                    label: Some(label.to_string()),
+                    label: Some(label),
                     id: None,
                     annotation_type: AnnotationType::Error,
                 }),
                 slices: vec![],
                 footer: vec![],
+                opt: FormatOptions {
+                    color: true,
+                    ..Default::default()
+                },
             },
         }
     }
@@ -29,16 +32,16 @@ impl Error {
         line_start: usize,
         start: usize,
         end: usize,
-        source: impl ToString,
-        label: impl ToString,
+        source: &'a str,
+        label: &'a str,
     ) -> Self {
         self.snippet.slices.push(Slice {
-            source: source.to_string(),
+            source: source,
             line_start,
             origin: None,
             fold: false,
             annotations: vec![SourceAnnotation {
-                label: label.to_string(),
+                label: label,
                 annotation_type: AnnotationType::Error,
                 range: (start, end),
             }],
@@ -47,9 +50,9 @@ impl Error {
     }
 
     /// Create a new footer.
-    pub fn help(mut self, label: impl ToString) -> Self {
+    pub fn help(mut self, label: &'a str) -> Self {
         self.snippet.footer.push(Annotation {
-            label: Some(label.to_string()),
+            label: Some(label),
             id: None,
             annotation_type: AnnotationType::Help,
         });
@@ -57,8 +60,6 @@ impl Error {
     }
 
     pub fn to_string(self) -> String {
-        let dl = DisplayList::from(self.snippet);
-        let dlf = DisplayListFormatter::new(true, false);
-        format!("{}", dlf.format(&dl))
+        DisplayList::from(self.snippet).to_string()
     }
 }

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,24 +1,27 @@
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
+use annotate_snippets::display_list::{DisplayList, FormatOptions};
 use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 
 /// An warning formatter.
-pub struct Warning {
-    snippet: Snippet,
+pub struct Warning<'a> {
+    snippet: Snippet<'a>,
 }
 
-impl Warning {
+impl<'a> Warning<'a> {
     /// Create a new `Warning` formatter.
-    pub fn new(label: impl ToString) -> Self {
+    pub fn new(label: &'a str) -> Self {
         Self {
             snippet: Snippet {
                 title: Some(Annotation {
-                    label: Some(label.to_string()),
+                    label: Some(label),
                     id: None,
                     annotation_type: AnnotationType::Warning,
                 }),
                 slices: vec![],
                 footer: vec![],
+                opt: FormatOptions {
+                    color: true,
+                    ..Default::default()
+                },
             },
         }
     }
@@ -29,16 +32,16 @@ impl Warning {
         line_start: usize,
         start: usize,
         end: usize,
-        source: impl ToString,
-        label: impl ToString,
+        source: &'a str,
+        label: &'a str,
     ) -> Self {
         self.snippet.slices.push(Slice {
-            source: source.to_string(),
+            source: source,
             line_start,
             origin: None,
             fold: false,
             annotations: vec![SourceAnnotation {
-                label: label.to_string(),
+                label: label,
                 annotation_type: AnnotationType::Warning,
                 range: (start, end),
             }],
@@ -47,9 +50,9 @@ impl Warning {
     }
 
     /// Create a new footer.
-    pub fn help(mut self, label: impl ToString) -> Self {
+    pub fn help(mut self, label: &'a str) -> Self {
         self.snippet.footer.push(Annotation {
-            label: Some(label.to_string()),
+            label: Some(label),
             id: None,
             annotation_type: AnnotationType::Help,
         });
@@ -57,8 +60,6 @@ impl Warning {
     }
 
     pub fn to_string(self) -> String {
-        let dl = DisplayList::from(self.snippet);
-        let dlf = DisplayListFormatter::new(true, false);
-        format!("{}", dlf.format(&dl))
+        DisplayList::from(self.snippet).to_string()
     }
 }


### PR DESCRIPTION
Hi!

This upgrades use of the `annotate-snippets` dependency to be compatible with the latest version — `0.9.1`.

They made a few changes, notably:
- [Strings are borrowed instead of copied](https://github.com/rust-lang/annotate-snippets-rs/pull/32)
- [The `DisplayListFormatter` has been replaced with `std::format::Display`](https://github.com/rust-lang/annotate-snippets-rs/pull/27)

I'm new to Rust so any feedback is very welcome! I'm not sure but I presume the changes from `impl ToString` to `&'a str` are not always backwards compatible?